### PR TITLE
Fix passed data in Pokemon click event

### DIFF
--- a/module/main.js
+++ b/module/main.js
@@ -227,7 +227,7 @@ require('../style.css');
                 icon: icon
             });
 
-            marker.addTo(pokemonLayer).on('click', fireEvent.bind({}, 'click', pokemon.pokemonId));
+            marker.addTo(pokemonLayer).on('click', fireEvent.bind({}, 'click', pokemon));
 
             return marker;
 


### PR DESCRIPTION
When a Pokemon is clicked you are passing the `pokemonId` but you we are expecting the entire PokeSighting object.
